### PR TITLE
Add ad-hoc docker deployment config

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:1.13
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/web/docker-compose.yml
+++ b/web/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3"
+services:
+  web:
+    build: .
+    ports:
+      - "80:80"
+      - "443:443"
+    network_mode: "host"
+    volumes:
+      - ./certs:/certs
+  httpproxy:
+    image: jupyterhub/configurable-http-proxy:latest
+    environment:
+      - CONFIGPROXY_AUTH_TOKEN=cf45c560c77803dfd7963db2df102c35593bd2892efa734fa6e1b44a13f0
+    network_mode: "host"
+    ports:
+      - 8000:8000
+    command: --default-target http://127.0.0.1:9999
+
+  tmpnb-orchestrate:
+    image: jupyter/tmpnb:latest
+    depends_on:
+      - httpproxy
+    network_mode: "host"
+    ports:
+      - "9999:9999"
+    volumes:
+      - /var/run/docker.sock:/docker.sock
+    environment:
+      - CONFIGPROXY_AUTH_TOKEN=cf45c560c77803dfd7963db2df102c35593bd2892efa734fa6e1b44a13f0
+    command: python orchestrate.py --image="dddecaf/cobra-notebook:ea01783d7808" --command='jupyter notebook --no-browser --port {port} --ip=0.0.0.0 --NotebookApp.base_url={base_path} --NotebookApp.port_retries=0 --NotebookApp.token="" --NotebookApp.disable_check_xsrf=True'
+

--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,0 +1,68 @@
+# Copyright 2018 Novo Nordisk Foundation Center for Biosustainability, DTU.
+#
+# Licensed under the Apache License, Version 2.0 (the \"License\");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an \"AS IS\" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+worker_processes 1;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    upstream try-cameo-bio {
+        server 127.0.0.1:8000;
+    }
+
+    server {
+        listen 80;
+        return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name try.cameo.bio;
+        ssl_certificate /certs/fullchain.pem;
+        ssl_certificate_key /certs/privkey.pem;
+
+        # modern configuration. tweak to your needs.
+        ssl_protocols TLSv1.2;
+        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+        ssl_prefer_server_ciphers on;
+
+        location / {
+            proxy_pass http://try-cameo-bio;
+
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            proxy_set_header X-NginX-Proxy true;
+        }
+
+        location ~* /(user[-/][a-zA-Z0-9]*)/(api/kernels/[^/]+/(channels|iopub|shell|stdin)|terminals/websocket)/? {
+            proxy_pass http://try-cameo-bio;
+
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+            proxy_set_header X-NginX-Proxy true;
+
+            # WebSocket support
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 86400;
+        }
+    }
+}


### PR DESCRIPTION
tmpnb is deprecated and should be replaced by maybe binder or jupyterhub, but for now the current ad-hoc deployment can be stored here